### PR TITLE
Allow the g++ executable to be set with an environment variable

### DIFF
--- a/rex/scripts/build-gpp.sh
+++ b/rex/scripts/build-gpp.sh
@@ -5,6 +5,8 @@
 #   - g++ (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
 #   - g++ (SUSE Linux) 11.2.1 20210816 [revision 056e324ce46a7924b5cf10f61010cf9dd2ca10e9]
 
+GPP="${GPP:-g++}"
+
 set -e
 cd "$(dirname "$0")/.."
 rm -f -r build
@@ -16,12 +18,12 @@ for CPP in $(find src -name '*.cpp'); do
   mkdir -p build/obj/${CPP%/*}
   echo $CPP
   set +e
-  g++ -std=gnu++17 -O3 -Wall -c -o $OBJ $CPP
+  $GPP -std=gnu++17 -O3 -Wall -c -o $OBJ $CPP
   set -e
 done
 
 mkdir -p build/bin
-CMD="g++ -o build/bin/rex $OBJECTS"
+CMD="$GPP -o build/bin/rex $OBJECTS"
 echo $CMD
 $CMD
 


### PR DESCRIPTION
AFAICT, `/usr/bin/gcc` on a Mac is an alias for clang.

If you install `gcc` on a (Apple Silicon) Mac with homebrew, it gets put in, for example, `/opt/homebrew/Cellar/gcc/14.2.0_1` and there are executables in the `bin` directory. But the executables all have version numbers in them. I suppose I could make `/usr/local/bin/g++` a link to `/opt/homebrew/Cellar/gcc/14.2.0_1/bin/g++-14` but that seems like crossing the streams a little bit.

This patch just makes it a tiny bit easier to build with the "right" version of GCC.

```
GPP=g++-14 sh scripts/build-gpp.sh
```

Just something to consider...